### PR TITLE
[SDK-6865] Modify custom configuration from podspec file

### DIFF
--- a/JWPlayer-SDK.podspec
+++ b/JWPlayer-SDK.podspec
@@ -15,10 +15,8 @@ Pod::Spec.new do |s|
 
   s.ios.vendored_frameworks = "JWPlayer_iOS_SDK.framework"
 
-  s.pod_target_xcconfig = {
-      'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
-  }
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator14.*]' => 'arm64' }
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator14.*]' => 'arm64' }
 
   s.requires_arc = true
 


### PR DESCRIPTION
Modifies custom configuration for the `EXCLUDE_ARCHS` build setting which will apply only for iPhone Simulator 14.0, this will avoid compiler warnings/errors for users who still using Xcode 11 or below.